### PR TITLE
Add unit preference for metric/imperial weights

### DIFF
--- a/frontend/app/(tabs)/friends/friend-profile.tsx
+++ b/frontend/app/(tabs)/friends/friend-profile.tsx
@@ -17,6 +17,7 @@ import { useThemeContext } from "@/context/ThemeContext";
 import Header from "@/components/Header";
 import DraggableBottomSheet from "@/components/DraggableBottomSheet";
 import pfptest from "@/assets/images/favicon.png";
+import { useWorkouts } from "@/context/WorkoutContext";
 
 /* ------------------------------------------------------------------ */
 /*                               Utils                                */
@@ -49,6 +50,8 @@ const ProgressBar: React.FC<{
 /* ------------------------------------------------------------------ */
 const FriendProfile = () => {
   const { primaryColor, secondaryColor, tertiaryColor } = useThemeContext();
+  const { unit } = useWorkouts();
+  const unitLabel = unit === "imperial" ? "lbs" : "kg";
 
   /* ---- params from FriendCard ---- */
   const {
@@ -79,6 +82,7 @@ const FriendProfile = () => {
   const xpNext      = (levelNum + 1) * 250;
   const workoutsNum = Number(workouts);
   const oneRmNum    = Number(oneRm);
+  const oneRmDisplay = unit === "imperial" ? oneRmNum : Math.round(oneRmNum / 2.20462);
   const friendsNum  = Number(friends);
 
   /* ---- options sheet ---- */
@@ -205,7 +209,7 @@ const FriendProfile = () => {
               className="text-white font-psemibold text-lg"
               style={{ color: primaryColor }}
             >
-              {oneRmNum} lbs
+              {oneRmDisplay} {unitLabel}
             </Text>
           </View>
         </View>

--- a/frontend/app/(tabs)/home/finished-workout.tsx
+++ b/frontend/app/(tabs)/home/finished-workout.tsx
@@ -13,6 +13,7 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeContext } from "@/context/ThemeContext";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import pfptest from "@/assets/images/favicon.png";
+import { useWorkouts } from "@/context/WorkoutContext";
 
 /* ------------------------------------------------------------------ */
 /*                           Types & Helpers                          */
@@ -52,6 +53,8 @@ const ProgressBar: React.FC<{
 const FinishedWorkout = () => {
   const { primaryColor, secondaryColor, tertiaryColor } = useThemeContext();
   const insets = useSafeAreaInsets();
+  const { unit } = useWorkouts();
+  const unitLabel = unit === "imperial" ? "lbs" : "kg";
 
   /* ------------------- params (mock fallback) ------------------- */
   const {
@@ -81,6 +84,7 @@ const FinishedWorkout = () => {
   const xpNextNum = Number(xpNext);
   const xpGainNum = Number(xpGained);
   const volumeNum = Number(volume);
+  const volumeDisplay = unit === "imperial" ? volumeNum : Math.round(volumeNum / 2.20462);
   const elapsedNum = Number(elapsed);
   const achievements: {
     id: string;
@@ -136,7 +140,7 @@ const FinishedWorkout = () => {
                 color={primaryColor}
               />
               <Text className="text-white mt-1 font-pmedium">
-                {volumeNum.toLocaleString()} lbs
+                {volumeDisplay.toLocaleString()} {unitLabel}
               </Text>
               <Text className="text-gray-100 text-xs">Total Volume</Text>
             </View>
@@ -237,7 +241,9 @@ const FinishedWorkout = () => {
                 >
                   <Text className="text-gray-100">Set {idx + 1}</Text>
                   <Text className="text-gray-100">{set.reps} reps</Text>
-                  <Text className="text-gray-100">{set.lbs} lbs</Text>
+                  <Text className="text-gray-100">
+                    {unit === "imperial" ? set.lbs : Math.round(set.lbs / 2.20462)} {unitLabel}
+                  </Text>
                   {set.isPR && (
                     <FontAwesome5
                       name="trophy"

--- a/frontend/app/(tabs)/profile/index.tsx
+++ b/frontend/app/(tabs)/profile/index.tsx
@@ -16,6 +16,7 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeContext } from "@/context/ThemeContext";
 import { useUser } from "@/context/UserProvider";
 import { useAuth } from "@/context/AuthProvider";
+import { useWorkouts } from "@/context/WorkoutContext";
 import TopBar from "@/components/TopBar";
 import defaultPfp from "@/assets/images/favicon.png";
 import { router } from "expo-router";
@@ -98,6 +99,9 @@ const ErrorCard: React.FC<{
 const Profile = () => {
   const { primaryColor, secondaryColor, tertiaryColor } = useThemeContext();
   const { user } = useAuth();
+  const { unit } = useWorkouts();
+  const unitLabel = unit === "imperial" ? "lbs" : "kg";
+  const benchWeight = unit === "imperial" ? 225 : Math.round(225 / 2.20462);
   const {
     profile,
     profilePictureUri,
@@ -320,7 +324,7 @@ const Profile = () => {
               className="text-white font-psemibold text-lg"
               style={{ color: primaryColor }}
             >
-              225 lbs
+              {benchWeight} {unitLabel}
             </Text>
           </View>
         </View>

--- a/frontend/app/(tabs)/profile/settings.tsx
+++ b/frontend/app/(tabs)/profile/settings.tsx
@@ -1,5 +1,5 @@
 // Path: /app/settings.tsx
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   View,
   Text,
@@ -15,11 +15,10 @@ import { router } from "expo-router";
 import FontAwesome5 from "@expo/vector-icons/FontAwesome5";
 import { useThemeContext } from "@/context/ThemeContext";
 import { useAuth } from "@/context/AuthProvider";
+import { useWorkouts } from "@/context/WorkoutContext";
 import logo from "@/assets/images/logo.png";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const APP_VERSION = "v0.8.3";
-const UNIT_KEY = "unit_preference";
 
 /* ------------------------------------------------------------------ */
 /*                               Row                                  */
@@ -53,24 +52,15 @@ const Row: React.FC<RowProps> = ({ label, icon, onPress }) => {
 const Settings = () => {
   const { primaryColor, secondaryColor, tertiaryColor } = useThemeContext();
   const { logout } = useAuth();
+  const { unit, setUnitPreference } = useWorkouts();
   const [loadingOut, setLoadingOut] = useState(false);
 
   /* -------- UNITS -------- */
-  const [unit, setUnit] = useState<"imperial" | "metric">("imperial");
   const [unitModalVisible, setUnitModalVisible] = useState(false);
-
-  /** Load saved preference on mount */
-  useEffect(() => {
-    (async () => {
-      const saved = await AsyncStorage.getItem(UNIT_KEY);
-      if (saved === "imperial" || saved === "metric") setUnit(saved);
-    })();
-  }, []);
 
   /** Persist preference and close modal */
   const chooseUnit = async (u: "imperial" | "metric") => {
-    setUnit(u);
-    await AsyncStorage.setItem(UNIT_KEY, u);
+    await setUnitPreference(u);
     setUnitModalVisible(false);
   };
 
@@ -129,7 +119,7 @@ const Settings = () => {
           onPress={() => router.push("/profile/account")}
         />
         <Row
-          label={`Units (${unit === "imperial" ? "lbs" : "kgs"})`}
+          label={`Units (${unit === "imperial" ? "lbs" : "kg"})`}
           icon="weight-hanging"
           onPress={() => setUnitModalVisible(true)}
         />
@@ -224,7 +214,7 @@ const Settings = () => {
                 color={primaryColor}
               />
               <Text className="text-white font-pmedium text-base ml-3">
-                Metric (kgs)
+                Metric (kg)
               </Text>
             </TouchableOpacity>
           </View>

--- a/frontend/components/home/ActiveWorkout/CarouselCard.tsx
+++ b/frontend/components/home/ActiveWorkout/CarouselCard.tsx
@@ -10,8 +10,11 @@ import {
   StyleSheet,
 } from "react-native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { useWorkouts } from "@/context/WorkoutContext";
 
 const MAX_FIELD_VALUE = 9999;
+const lbsToKg = (lbs: number) => lbs / 2.20462;
+const kgToLbs = (kg: number) => kg * 2.20462;
 
 export interface SetItem {
   id: number;
@@ -79,6 +82,8 @@ const ActiveWorkoutCard: React.FC<Props> = ({
 }) => {
   const editableBg = "rgba(255,255,255,0.08)";
   const listRef = useRef<ScrollView | null>(null);
+  const { unit } = useWorkouts();
+  const unitLabel = unit === "imperial" ? "lbs" : "kg";
 
   // Local editing controller (UI only; values saved via onUpdateSetField)
   const [editing, setEditing] = useState<EditingState>(null);
@@ -101,7 +106,8 @@ const ActiveWorkoutCard: React.FC<Props> = ({
 
   const beginEdit = (setIdx: number, field: "reps" | "lbs", current: number) => {
     setEditing({ setIdx, field });
-    setEditingValue(String(current));
+    const displayVal = field === "lbs" && unit === "metric" ? Math.round(lbsToKg(current)) : current;
+    setEditingValue(String(displayVal));
   };
 
   const commitEdit = () => {
@@ -113,6 +119,9 @@ const ActiveWorkoutCard: React.FC<Props> = ({
       return;
     }
     num = Math.max(0, Math.min(num, MAX_FIELD_VALUE));
+    if (editing.field === "lbs" && unit === "metric") {
+      num = Math.round(kgToLbs(num));
+    }
     onUpdateSetField(exIdx, editing.setIdx, editing.field, num);
     setEditing(null);
     setEditingValue("");
@@ -376,7 +385,7 @@ const ActiveWorkoutCard: React.FC<Props> = ({
                   }}
                 >
                   <Text className="text-gray-100" style={{ textAlign: "center" }}>
-                    {s.lbs} lbs
+                    {unit === "imperial" ? s.lbs : Math.round(lbsToKg(s.lbs))} {unitLabel}
                   </Text>
                 </TouchableOpacity>
               )}

--- a/frontend/components/home/ActivityView.tsx
+++ b/frontend/components/home/ActivityView.tsx
@@ -2,8 +2,12 @@ import { View, Text } from "react-native";
 import React from "react";
 import FontAwesome5 from "@expo/vector-icons/FontAwesome5";
 import { useThemeContext } from "@/context/ThemeContext";
+import { useWorkouts } from "@/context/WorkoutContext";
 export default function ActivityView() {
   const { primaryColor, tertiaryColor } = useThemeContext();
+  const { unit } = useWorkouts();
+  const unitLabel = unit === "imperial" ? "lbs" : "kg";
+  const benchWeight = unit === "imperial" ? 225 : Math.round(225 / 2.20462);
 
   return (
     <View>
@@ -23,7 +27,7 @@ export default function ActivityView() {
         </View>
         <View className="flex-1">
           <Text className="text-white font-pmedium">New Personal Best!</Text>
-          <Text className="text-gray-100">Bench Press: 225 lbs × 8 reps</Text>
+          <Text className="text-gray-100">Bench Press: {benchWeight} {unitLabel} × 8 reps</Text>
           <Text className="text-gray-100 text-xs mt-1">
             Yesterday at 7:24 PM
           </Text>

--- a/frontend/components/home/ExerciseCard.tsx
+++ b/frontend/components/home/ExerciseCard.tsx
@@ -16,6 +16,7 @@ import * as Haptics from "expo-haptics";
 import FontAwesome5 from "@expo/vector-icons/FontAwesome5";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeContext } from "@/context/ThemeContext";
+import { useWorkouts } from "@/context/WorkoutContext";
 import { router } from "expo-router";
 import { loadExercises } from "@/utils/loadExercises";
 import ReorderModal from "./ReorderModal";
@@ -97,6 +98,8 @@ const ExerciseCard: React.FC<ExerciseCardProps> = ({
   allExercises,
 }) => {
   const { primaryColor, tertiaryColor } = useThemeContext();
+  const { unit } = useWorkouts();
+  const unitLabel = unit === "imperial" ? "lbs" : "kg";
   const [isExpanded, setIsExpanded] = useState(false);
   const [showOptionsModal, setShowOptionsModal] = useState(false);
   const [showReorderModal, setShowReorderModal] = useState(false);
@@ -172,7 +175,7 @@ const ExerciseCard: React.FC<ExerciseCardProps> = ({
 
   const handleAddSet = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    const newSets = [...exercise.sets, { reps: "10", weight: "0 lbs" }];
+    const newSets = [...exercise.sets, { reps: "10", weight: `0 ${unitLabel}` }];
     onUpdate(exercise.id, "sets", newSets);
   };
 
@@ -232,7 +235,7 @@ const ExerciseCard: React.FC<ExerciseCardProps> = ({
     const weightDisplay =
       minWeight === maxWeight ? `${minWeight}` : `${minWeight}-${maxWeight}`;
 
-    return `${exercise.sets.length} sets • ${repsDisplay} reps • ${weightDisplay} lbs`;
+    return `${exercise.sets.length} sets • ${repsDisplay} reps • ${weightDisplay} ${unitLabel}`;
   };
 
   return (
@@ -478,7 +481,7 @@ const ExerciseCard: React.FC<ExerciseCardProps> = ({
                             handleSetUpdate(
                               setIndex,
                               "weight",
-                              numericValue ? `${numericValue} lbs` : "0 lbs"
+                              numericValue ? `${numericValue} ${unitLabel}` : `0 ${unitLabel}`
                             );
                           }}
                           keyboardType="numeric"
@@ -492,7 +495,7 @@ const ExerciseCard: React.FC<ExerciseCardProps> = ({
                             marginTop: 2,
                           }}
                         >
-                          weight (lbs)
+                          weight ({unitLabel})
                         </Text>
                       </View>
                     </View>

--- a/frontend/components/home/WorkoutEditor.tsx
+++ b/frontend/components/home/WorkoutEditor.tsx
@@ -77,7 +77,9 @@ const WorkoutEditor: React.FC<WorkoutEditorProps> = ({ mode, dayParam }) => {
     createWorkout,
     updateWorkout,
     isLoading: contextLoading,
+    unit,
   } = useWorkouts();
+  const unitLabel = unit === "imperial" ? "lbs" : "kg";
 
   const [workout, setWorkout] = useState<Workout>({
     name: "",
@@ -152,7 +154,7 @@ const WorkoutEditor: React.FC<WorkoutEditorProps> = ({ mode, dayParam }) => {
             setExistingWorkoutId(existingWorkout.id);
 
             const transformedExercises = existingWorkout.exercises.map((ex) =>
-              transformExerciseFromAPI(ex, exerciseDatabase)
+              transformExerciseFromAPI(ex, exerciseDatabase, unit)
             );
 
             const derivedDays = deriveDaysForWorkout(existingWorkout);
@@ -175,7 +177,7 @@ const WorkoutEditor: React.FC<WorkoutEditorProps> = ({ mode, dayParam }) => {
             setExistingWorkoutId(existingWorkout.id);
 
             const transformedExercises = existingWorkout.exercises.map((ex) =>
-              transformExerciseFromAPI(ex, exerciseDatabase)
+              transformExerciseFromAPI(ex, exerciseDatabase, unit)
             );
 
             // UPDATED: include ALL days this workout appears on, not just dayParam
@@ -240,9 +242,9 @@ const WorkoutEditor: React.FC<WorkoutEditorProps> = ({ mode, dayParam }) => {
       id: generateId(),
       name: ex.name,
       sets: [
-        { reps: "10", weight: "0 lbs" },
-        { reps: "10", weight: "0 lbs" },
-        { reps: "10", weight: "0 lbs" },
+        { reps: "10", weight: `0 ${unitLabel}` },
+        { reps: "10", weight: `0 ${unitLabel}` },
+        { reps: "10", weight: `0 ${unitLabel}` },
       ],
       notes: "",
       originalExerciseId: ex.id,
@@ -259,9 +261,9 @@ const WorkoutEditor: React.FC<WorkoutEditorProps> = ({ mode, dayParam }) => {
       id: exerciseId, // Keep the same ID
       name: newExerciseData.name,
       sets: [
-        { reps: "10", weight: "0 lbs" },
-        { reps: "10", weight: "0 lbs" },
-        { reps: "10", weight: "0 lbs" },
+        { reps: "10", weight: `0 ${unitLabel}` },
+        { reps: "10", weight: `0 ${unitLabel}` },
+        { reps: "10", weight: `0 ${unitLabel}` },
       ],
       notes: "",
       originalExerciseId: newExerciseData.id,


### PR DESCRIPTION
## Summary
- persist user-selected units in workout context
- display weights in lbs or kg across activity, workouts, and profiles
- convert exercise weights when syncing with API

## Testing
- `npm test -- --watchAll=false` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950b95e430832dab5888d06583dbae